### PR TITLE
Feature/92 self naming children

### DIFF
--- a/src/actions/entity.js
+++ b/src/actions/entity.js
@@ -1,5 +1,6 @@
 import startCase from "lodash/startCase"
 import camelCase from "lodash/camelCase"
+import padStart from "lodash/padStart"
 
 import {
   selectNewEntityPath,
@@ -18,6 +19,23 @@ export function startEntityCreation() {
       type: "START_ENTITY_CREATION",
       payload: {
         id: "",
+        template: templates[0],
+        templates
+      }
+    })
+  }
+}
+export function startNumberedEntityCreation(count = 0) {
+  return (dispatch, getState) => {
+    const state = getState()
+    const templates = selectTemplateChildren(state)
+    const id = `${startCase(templates[0].split("/").slice(-1))} ${padStart(count, 3, "0")}`
+    console.log("NEXT ID", id)
+
+    dispatch({
+      type: "START_ENTITY_CREATION",
+      payload: {
+        id,
         template: templates[0],
         templates
       }

--- a/src/actions/entity.js
+++ b/src/actions/entity.js
@@ -25,13 +25,39 @@ export function startEntityCreation() {
     })
   }
 }
-export function startNumberedEntityCreation(count = 0) {
+
+function findNextIndex(children, templateName) {
+  const nextIndexInvalid = (cs, nIndex) => cs.some(child => {
+    const templateMatch = child.name.toLowerCase().startsWith(templateName)
+    let indexEquals = false
+    const indexStringMatch = child.name.match(/(\d+)$/g)
+    if (indexStringMatch) {
+      const indexString = indexStringMatch.pop()
+      if (indexString) {
+        indexEquals = nIndex === Number.parseInt(indexString, 10)
+      }
+    }
+    return templateMatch && indexEquals
+  })
+  const startIndex = 1
+  let nextIndex = startIndex
+  while (nextIndexInvalid(children, nextIndex)) {
+    nextIndex++
+  }
+  // console.log("found next ID", nextIndex)
+  return nextIndex
+}
+
+export function startNumberedEntityCreation(children) {
   return (dispatch, getState) => {
     const state = getState()
     const templates = selectTemplateChildren(state)
-    const id = `${startCase(templates[0].split("/").slice(-1))} ${padStart(count, 3, "0")}`
-    console.log("NEXT ID", id)
-
+    let id = ""
+    if (templates.length === 1) {
+      const templateName = templates[0].split("/").slice(-1).toString().toLowerCase()
+      const nextIndex = findNextIndex(children, templateName)
+      id = `${startCase(templateName)} ${padStart(nextIndex, 3, "0")}`
+    }
     dispatch({
       type: "START_ENTITY_CREATION",
       payload: {
@@ -42,6 +68,7 @@ export function startNumberedEntityCreation(count = 0) {
     })
   }
 }
+
 
 export function updateEntityCreationId(id) {
   return {

--- a/src/actions/value.js
+++ b/src/actions/value.js
@@ -23,3 +23,7 @@ export function undoChanges(path) {
     })
   }
 }
+
+export function clearSrcTag(path) {
+  return changeValue(path, "")
+}

--- a/src/components/body/field/characterCount.js
+++ b/src/components/body/field/characterCount.js
@@ -1,5 +1,5 @@
 import React from "react"
 
 export default function CharacterCount({ value, maxLength }) {
-  return <small className="text-muted"> { `${maxLength - value.length}  /  ${maxLength}` } </small>
+  return <small className="text-muted"> { `${value.length}  /  ${maxLength}` } </small>
 }

--- a/src/components/body/field/fieldHeader.js
+++ b/src/components/body/field/fieldHeader.js
@@ -5,7 +5,7 @@ import Dropdown from "react-bootstrap/Dropdown"
 import DropdownItem from "react-bootstrap/DropdownItem"
 import styled from "styled-components"
 
-import { undoChanges } from "../../../actions/value"
+import { undoChanges, clearSrcTag } from "../../../actions/value"
 
 import ToggleButton from "../../toggleButton"
 import CharacterCount from "./characterCount"
@@ -40,6 +40,13 @@ const FieldHeader = ({ field, dispatch }) =>
           onSelect={ () => dispatch(undoChanges(field.path)) }>
           Undo Changes
         </DropdownItem>
+        { (field.type === "image" || field.type === "video") &&
+        <DropdownItem
+          key="clear"
+          disabled={ !field.hasChanged || field.isNew }
+          onSelect={ () => dispatch(clearSrcTag(field.path)) }>
+          Clear
+        </DropdownItem> }
       </Dropdown.Menu>
     </StyledDropdown>
   </Flexbox>

--- a/src/components/body/index.js
+++ b/src/components/body/index.js
@@ -12,7 +12,10 @@ import Row from "react-bootstrap/Row"
 import ChildItem from "./childItem"
 import Field from "./field"
 
-import { deleteEntity, startEntityCreation, startNumberedEntityCreation, startEntityRenaming } from "../../actions/entity"
+import {
+  deleteEntity,
+  startNumberedEntityCreation,
+  startEntityRenaming } from "../../actions/entity"
 import { undoChanges } from "../../actions/value"
 
 import {

--- a/src/components/body/index.js
+++ b/src/components/body/index.js
@@ -12,7 +12,7 @@ import Row from "react-bootstrap/Row"
 import ChildItem from "./childItem"
 import Field from "./field"
 
-import { deleteEntity, startEntityCreation, startEntityRenaming } from "../../actions/entity"
+import { deleteEntity, startEntityCreation, startNumberedEntityCreation, startEntityRenaming } from "../../actions/entity"
 import { undoChanges } from "../../actions/value"
 
 import {
@@ -122,7 +122,7 @@ function renderChildren(children, dispatch, canHaveChildren) {
         <AddButton
           variant="secondary"
           action
-          onClick={ () => dispatch(startEntityCreation()) }>+
+          onClick={ () => dispatch(startNumberedEntityCreation(children.length)) }>+
         </AddButton>
       }
     </ListGroup>

--- a/src/components/body/index.js
+++ b/src/components/body/index.js
@@ -125,7 +125,7 @@ function renderChildren(children, dispatch, canHaveChildren) {
         <AddButton
           variant="secondary"
           action
-          onClick={ () => dispatch(startNumberedEntityCreation(children.length)) }>+
+          onClick={ () => dispatch(startNumberedEntityCreation(children)) }>+
         </AddButton>
       }
     </ListGroup>


### PR DESCRIPTION
Caveats:
- the method for finding the current index is pretty crude, it just takes the length of the children array. A more intelligent approach would match the template name against the children array members.
- the modal still appears, impacting the maximum speed of child creation. Solution proposition: auto-focus the `Create` button thus enabling a rapid confirmation by pressing `enter`.
- **TODO**: remove unnecessary `logging` activity.